### PR TITLE
Added 'woocommerce_form_field_container' to woocommerce_form_field()

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2162,7 +2162,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$field           = '';
 		$label_id        = $args['id'];
 		$sort            = $args['priority'] ? $args['priority'] : '';
-		$field_container = '<p class="form-row %1$s" id="%2$s" data-priority="' . esc_attr( $sort ) . '">%3$s</p>';
++		$field_container = apply_filters( 'woocommerce_form_field_container', '<p class="form-row %1$s" id="%2$s" data-sort="' . esc_attr( $sort ) . '">%3$s</p>', $key, $args, $value );
 
 		switch ( $args['type'] ) {
 			case 'country':


### PR DESCRIPTION
Allows the form field function to be filterable. At present this enforces the container to be a P tag and to contain the form-row class. The class in particular clashes with the bootstrap4 form class and can't be replaced through existing filters.